### PR TITLE
Add initial AHB support

### DIFF
--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.cpp
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.cpp
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2010-2022 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+#include "ahb.h"
+#include <cmath>
+
+BaseAHB::BaseAHB(uint32_t dataWidth, uint32_t addrWidth)
+{
+    if(dataWidth != 32)
+        throw "Unsupported AHB data width";
+
+    this->dataWidth = dataWidth;
+
+    if(addrWidth != 32)
+        throw "Unsupported AHB address width";
+
+    this->addrWidth = addrWidth;
+}
+
+AHB::AHB(uint32_t dataWidth, uint32_t addrWidth) : BaseAHB(dataWidth, addrWidth)
+{
+}
+
+void AHB::tick(bool countEnable, uint64_t steps = 1)
+{
+    for(uint64_t i = 0; i < steps; i++) {
+        *hclk = 1;
+        evaluateModel();
+        *hclk = 0;
+        evaluateModel();
+    }
+
+    if(countEnable) {
+        tickCounter += steps;
+    }
+}
+
+void AHB::timeoutTick(uint8_t* signal, uint8_t expectedValue, int timeout = DEFAULT_TIMEOUT)
+{
+    do
+    {
+        tick(true);
+        timeout--;
+    }
+    while((*signal != expectedValue) && timeout > 0);
+
+    if(timeout == 0) {
+        throw "Operation timeout";
+    }
+}
+
+void AHB::write(int width, uint64_t addr, uint64_t value)
+{
+    if(width != 4) {
+        char msg[] = "AHB implementation only handles 4-byte accesses, tried %d"; // we sprintf to self, because width is never longer than 2 digits
+        sprintf(msg, msg, width);
+        throw msg;
+    }
+    *htrans = 0;
+    *hwrite = 0;
+    *hsize = 0;
+    *hburst = 0;
+    *hprot = 0;
+    *error = 0;
+
+    tick(true);
+
+    *htrans = 2;
+    *hwrite = 1;
+    *hsize = 2;
+
+    *haddr = addr;
+    *hwdata = value;
+
+    timeoutTick(hready, 1);
+
+    *hsel = 1;
+
+    tick(true);
+
+    *hsel = 0;
+
+    tick(true);
+}
+
+uint64_t AHB::read(int width, uint64_t addr)
+{
+    if(width != 4) {
+        char msg[] = "AHB implementation only handles 4-byte accesses, tried %d"; // we sprintf to self, because width is never longer than 2 digits
+        sprintf(msg, msg, width);
+        throw msg;
+    }
+    *hsel = 1;
+    *hwrite = 0;
+
+    *htrans = 2;
+    *hsize = 2;
+
+    *haddr = addr;
+
+    timeoutTick(hready, 1);
+
+    *hsel = 1;
+
+    tick(true);
+
+    uint64_t result = *hrdata;
+
+    *hsel = 0;
+
+    tick(true);
+
+    return result;
+}
+
+void AHB::reset()
+{
+    *hresetn = 0;
+    tick(true);
+    *hresetn = 0;
+    tick(true);
+    *hresetn = 1;
+    tick(true);
+}

--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.h
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.h
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2010-2022 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+#ifndef AHB_H
+#define AHB_H
+#include "bus.h"
+#include <src/renode_bus.h>
+
+struct BaseAHB
+{
+    BaseAHB(uint32_t dataWidth, uint32_t addrWidth);
+
+    uint32_t dataWidth;
+    uint32_t addrWidth;
+
+    uint8_t *hclk;
+    uint8_t *hresetn;
+    uint8_t *hsel;          // IN
+    uint32_t *haddr;        // IN
+    uint8_t *htrans;        // IN
+    uint8_t *hwrite;        // IN
+    uint8_t *hsize;         // IN
+    uint8_t *hburst;        // IN
+    uint8_t *hprot;         // IN
+    uint32_t *hwdata;       // IN
+    uint8_t *error;         // IN
+    //
+    uint32_t *hrdata;       // OUT
+    uint8_t *hready;        // OUT
+    uint8_t *hresp;         // OUT
+
+};
+
+struct AHB : public BaseAHB, public BaseTargetBus
+{
+    AHB(uint32_t dataWidth, uint32_t addrWidth);
+    virtual void tick(bool countEnable, uint64_t steps);
+    virtual void write(int width, uint64_t addr, uint64_t value);
+    virtual uint64_t read(int width, uint64_t addr);
+    virtual void reset();
+    void timeoutTick(uint8_t* signal, uint8_t expectedValue, int timeout);
+};
+#endif


### PR DESCRIPTION
Initial AHB support for single burst transactions is added to Renode socket communication method with AHB slave verilated designs
