### PR TITLE
AHB byte and half-word support

### DIFF
--- a/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.cpp
+++ b/src/Plugins/VerilatorPlugin/VerilatorIntegrationLibrary/src/buses/ahb.cpp
@@ -75,7 +75,7 @@ void AHB::write(int width, uint64_t addr, uint64_t value)
     *ahb_hwdata = value;
 
     *ahb_hwrite = 1;
-    *ahb_hsize = 2;
+    *ahb_hsize = width >> 1;
 
     timeoutTick(ahb_hreadyout, 1);
 
@@ -112,7 +112,7 @@ uint64_t AHB::read(int width, uint64_t addr)
 
     tick(true);
 
-    *ahb_hsize = 2;
+    *ahb_hsize = width >> 1;
 
     timeoutTick(ahb_hreadyout, 1);
 


### PR DESCRIPTION
As per DMA transaction, it is confirmed that AHB master (Renode side) receives byte and half-word transcations properly, both in address and data but also width parameter is passed properly. With this AHB master is changed to properly pass the parameter to ahb_hsize signal.